### PR TITLE
fix: TestRun instance is not leaked

### DIFF
--- a/src/Deltics.Smoketest.TestRun.pas
+++ b/src/Deltics.Smoketest.TestRun.pas
@@ -1,4 +1,4 @@
-{
+﻿{
   * MIT LICENSE *
 
   Copyright © 2019 Jolyon Smith
@@ -1064,7 +1064,11 @@ initialization
   TestRun := TTestRun.Create;
 
 finalization
-  if Assigned(TestRun) and NOT TestRun.IsFinished then
-    TestRun.Complete;
+  try
+    if Assigned(TestRun) and NOT TestRun.IsFinished then
+      TestRun.Complete;
 
+  finally
+    TestRun.Free;
+  end;
 end.


### PR DESCRIPTION
Ensure that the TestRun instance is Free'd when the framework is finalized (process termination)