### PR TITLE
Xml encoding of extended/supplementary characters

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 mode: ContinuousDeployment
 increment: None
-next-version: 2.7.1
+next-version: 2.7.2
 branches:
   master:
     mode: ContinuousDelivery

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 mode: ContinuousDeployment
 increment: None
-next-version: 2.7.0
+next-version: 2.7.1
 branches:
   master:
     mode: ContinuousDelivery

--- a/src/Deltics.Smoketest.Utils.pas
+++ b/src/Deltics.Smoketest.Utils.pas
@@ -747,7 +747,7 @@ implementation
         end;
       {$endif}
 
-        Append('&#x' + BinToHex(@c, 2) + ';');
+        Append('&#x' + BinToHex(@c, sizeof(Char)) + ';');
       end
       else case c of
         TAB : Append('&#x9;');

--- a/src/Deltics.Smoketest.Utils.pas
+++ b/src/Deltics.Smoketest.Utils.pas
@@ -766,8 +766,10 @@ implementation
       end;
     end;
 
+  {$ifdef UNICODE}
     if hiSurrogate <> #$0000 then
       Append('U+' + Uppercase(BinToHex(@hiSurrogate, 2)));
+  {$endif}
 
     SetLength(result, j);
   end;

--- a/tests/Test.Utils.pas
+++ b/tests/Test.Utils.pas
@@ -52,6 +52,8 @@ interface
       procedure BinToHexEncodesCorrectly;
       procedure XmlEncodedAttrEncodesSymbolsCorrectly;
     {$ifdef UNICODE}
+      procedure XmlEncodedAttrEncodesOrphanedHiSurrogateAsCodeReferencesNotEntities;
+      procedure XmlEncodedAttrEncodesOrphanedLoSurrogateAsCodeReferencesNotEntities;
       procedure XmlEncodedAttrEncodesSupplementaryCharactersCorrectly;
     {$endif}
     end;
@@ -93,9 +95,27 @@ implementation
 
 
 {$ifdef UNICODE}
+  procedure TUtilsTests.XmlEncodedAttrEncodesOrphanedHiSurrogateAsCodeReferencesNotEntities;
+  const
+    HI = WideChar($d834);
+  begin
+    Test('XmlEncodedAttr(''' + HI + ''')').Assert(XmlEncodedAttr(HI)).Equals('U+D834');
+    Test('XmlEncodedAttr(''' + HI + HI + ''')').Assert(XmlEncodedAttr(HI + HI)).Equals('U+D834U+D834');
+  end;
+
+
+  procedure TUtilsTests.XmlEncodedAttrEncodesOrphanedLoSurrogateAsCodeReferencesNotEntities;
+  const
+    LO = WideChar($dd1e);
+  begin
+    Test('XmlEncodedAttr(''' + LO + ''')').Assert(XmlEncodedAttr(LO)).Equals('U+DD1E');
+    Test('XmlEncodedAttr(''' + LO + LO + ''')').Assert(XmlEncodedAttr(LO + LO)).Equals('U+DD1EU+DD1E');
+  end;
+
+
   procedure TUtilsTests.XmlEncodedAttrEncodesSupplementaryCharactersCorrectly;
   const
-    CODEPOINT = '0001d11e';
+    CODEPOINT = '01d11e';
     CLEF      = WideChar($d834) + WideChar($dd1e);
   begin
     Test('XmlEncodedAttr(''' + CLEF + ''')').Assert(XmlEncodedAttr(CLEF)).Equals('&#x' + CODEPOINT + ';');


### PR DESCRIPTION
Fixes an issue where orphaned surrogates (e.g. in test descriptions, specifically testing surrogates) would be encoded as xml entities, causing the results publication on Azure DevOps to fail (due to the entity encoding of an orphaned surrogate being interpreted as an invalid encoding).